### PR TITLE
Support SGX 2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,22 @@
 FROM ubuntu:bionic
 
-WORKDIR /usr/src/sdk
+WORKDIR /usr/src/app
 
-RUN apt-get update && apt-get install -yq --no-install-recommends ca-certificates build-essential ocaml ocamlbuild automake autoconf libtool wget python libssl-dev libssl-dev libcurl4-openssl-dev protobuf-compiler git libprotobuf-dev alien cmake debhelper uuid-dev libxml2-dev
-
-RUN wget --progress=dot:mega -O iclsclient.rpm http://registrationcenter-download.intel.com/akdlm/irc_nas/11414/iclsClient-1.45.449.12-1.x86_64.rpm && \
-    alien --scripts -i iclsclient.rpm && \
-    rm iclsclient.rpm
-
-RUN wget --progress=dot:mega -O - https://github.com/intel/dynamic-application-loader-host-interface/archive/072d233296c15d0dcd1fb4570694d0244729f87b.tar.gz | tar -xz && \
-    cd dynamic-application-loader-host-interface-072d233296c15d0dcd1fb4570694d0244729f87b && \
-    cmake . -DCMAKE_BUILD_TYPE=Release -DINIT_SYSTEM=SysVinit && \
-    make install && \
-    cd .. && rm -rf dynamic-application-loader-host-interface-072d233296c15d0dcd1fb4570694d0244729f87b
+RUN apt-get update && apt-get install -yq --no-install-recommends ca-certificates build-essential ocaml ocamlbuild automake autoconf libtool wget python libssl-dev libssl-dev libcurl4-openssl-dev protobuf-compiler git libprotobuf-dev alien cmake debhelper uuid-dev libxml2-dev lsb-release
 
 COPY install-psw.patch ./
 
-RUN git clone -b sgx_2.5 --depth 1 https://github.com/intel/linux-sgx && \
-    cd linux-sgx && \
+RUN git clone -b sgx_2.6 --depth 1 https://github.com/intel/linux-sgx
+
+RUN cd linux-sgx && \
     patch -p1 -i ../install-psw.patch && \
     ./download_prebuilt.sh 2> /dev/null && \
-    make -s -j$(nproc) sdk_install_pkg psw_install_pkg && \
-    ./linux/installer/bin/sgx_linux_x64_sdk_2.5.100.49891.bin --prefix=/opt/intel && \
-    ./linux/installer/bin/sgx_linux_x64_psw_2.5.100.49891.bin && \
-    cd .. && rm -rf linux-sgx/
-
-WORKDIR /usr/src/app
+    make -s -j$(nproc) && make -s -j$(nproc) sdk_install_pkg deb_pkg && \
+    ./linux/installer/bin/sgx_linux_x64_sdk_2.6.100.51363.bin --prefix=/opt/intel && \
+    cd linux/installer/deb/ && \
+    dpkg -i libsgx-urts_2.6.100.51363-bionic1_amd64.deb libsgx-enclave-common_2.6.100.51363-bionic1_amd64.deb && \
+    cd ../../../.. && rm -rf linux-sgx/
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
-# For debug purposes
-# COPY jhi.conf /etc/jhi/jhi.conf

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Instructions:
 * sgx_2.3.1
 * sgx_2.4
 * sgx_2.5
+* sgx_2.6
 
 ## Example Dockerfile
 
@@ -26,7 +27,7 @@ Example using `SampleEnclave` shipped with the official SDK
 **Dockerfile**
 
 ```Dockerfile
-FROM sebvaucher/sgx-base:sgx_2.5
+FROM sebvaucher/sgx-base:sgx_2.6
 
 COPY . ./
 RUN make SGX_DEBUG=0 SGX_PRERELEASE=1 SGX_MODE=HW

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
 source /opt/intel/sgxsdk/environment
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/sgxpsw/aesm/
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/libsgx-enclave-common/aesm/
 
-jhid -d
-/opt/intel/sgxpsw/aesm/aesm_service &
+/opt/intel/libsgx-enclave-common/aesm/aesm_service &
 pid=$!
 
 trap "kill ${pid}" TERM INT

--- a/install-psw.patch
+++ b/install-psw.patch
@@ -1,5 +1,5 @@
 diff --git a/linux/installer/bin/install-sgx-psw.bin.tmpl b/linux/installer/bin/install-sgx-psw.bin.tmpl
-index 3510e97c..751831ab 100755
+index 3510e97..751831a 100755
 --- a/linux/installer/bin/install-sgx-psw.bin.tmpl
 +++ b/linux/installer/bin/install-sgx-psw.bin.tmpl
 @@ -30,34 +30,10 @@
@@ -38,7 +38,7 @@ index 3510e97c..751831ab 100755
  ARCH=$(uname -m)
  
 diff --git a/linux/installer/common/libsgx-enclave-common/install.sh b/linux/installer/common/libsgx-enclave-common/install.sh
-index 296879af..851d520b 100755
+index 20d8b17..23fe7b8 100755
 --- a/linux/installer/common/libsgx-enclave-common/install.sh
 +++ b/linux/installer/common/libsgx-enclave-common/install.sh
 @@ -33,11 +33,6 @@
@@ -53,23 +53,27 @@ index 296879af..851d520b 100755
  SCRIPT_DIR=$(dirname "$0")
  source ${SCRIPT_DIR}/installConfig
  
-@@ -95,7 +90,7 @@ elif [ -d /etc/init/ ]; then
+@@ -93,9 +88,7 @@ elif [ -d /etc/init/ ]; then
+     /sbin/initctl reload-configuration
+     retval=$?
  else
-     echo " failed."
-     echo "Unsupported platform - neither systemctl nor initctl is found."
+-    echo " failed."
+-    echo "Unsupported platform - neither systemctl nor initctl is found."
 -    exit 5
 +    retval=0
  fi
  
  if test $retval -ne 0; then
 diff --git a/linux/installer/common/psw/install.sh b/linux/installer/common/psw/install.sh
-index 59f3ed61..8ba940a3 100755
+index 49fd2f7..637a5fe 100755
 --- a/linux/installer/common/psw/install.sh
 +++ b/linux/installer/common/psw/install.sh
-@@ -96,7 +96,7 @@ elif [ -d /etc/init/ ]; then
+@@ -94,9 +94,7 @@ elif [ -d /etc/init/ ]; then
+     /sbin/initctl reload-configuration
+     retval=$?
  else
-     echo " failed."
-     echo "Unsupported platform - neither systemctl nor initctl is found."
+-    echo " failed."
+-    echo "Unsupported platform - neither systemctl nor initctl is found."
 -    exit 5
 +    retval=0
  fi


### PR DESCRIPTION
Main changes include:
* Removed icls client installation (no longer publicly distributed by Intel);
* Removed dalhi installation (no longer needed since icls client is not available);
* Removed jhi daemon from entrypoint script (no longer available); 
* Updated SGX PSW installer to use generated deb package;
* Updated AESM daemon path;
* Updated README file to include SGX 2.6.

**Note:** Platform Services (pse session, monotonic counter, trusted relative time) are no longer usable since icls client is not publicly available anymore.

Signed-off-by: Rodolfo Marinho <rodolfo@grupomarinho.com.br>